### PR TITLE
Fix for CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')

### DIFF
--- a/insecure-java/src/main/java/com/example/catapp/controllers/CommentController.java
+++ b/insecure-java/src/main/java/com/example/catapp/controllers/CommentController.java
@@ -1,5 +1,6 @@
 package com.example.catapp.controllers;
 
+import org.apache.commons.text.StringEscapeUtils;
 import com.example.catapp.models.Comment;
 import com.example.catapp.repositories.CommentRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,7 +25,7 @@ public class CommentController {
     @PostMapping("/addComment")
     public String addComment(@RequestParam String commentText, Model model) {
         Comment comment = new Comment();
-        comment.setText(commentText); // No sanitization
+        comment.setText(StringEscapeUtils.escapeHtml4(commentText)); // Sanitize input
         commentRepository.save(comment);
         model.addAttribute("message", "Comment added");
         return "addCommentResult"; // Returns addCommentResult.html


### PR DESCRIPTION
🐕 [Corgea](https://www.corgea.com) issued a PR to fix a vulnerability found in insecure-java/src/main/java/com/example/catapp/controllers/CommentController.java.

It is CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting') that has a severity of :red_circle: High.

### 🪄 Fix explanation
The fix mitigates the XSS vulnerability by sanitizing user input using &quot;StringEscapeUtils.escapeHtml4&quot;, which neutralizes potentially harmful HTML content before storing it in the database.<br>-        The fix imports &quot;StringEscapeUtils&quot; from Apache Commons Text to handle input sanitization.<br>        -        The method &quot;escapeHtml4&quot; is applied to &quot;commentText&quot; to escape HTML tags, preventing script execution.<br>        -        The sanitized input is then safely stored in the &quot;Comment&quot; object, mitigating XSS risks.<br>    

### 💡 Important Instructions
Ensure that all user inputs across the application are similarly sanitized to prevent XSS vulnerabilities.

[See the issue and fix in Corgea.](https://www.corgea.app/issue/8ef124eb-5a30-4f03-a2c6-3fa24d0434a6)

