### PR TITLE
Fix for CWE-798: Use of Hard-coded Credentials

### DIFF
--- a/insecure-api/main.py
+++ b/insecure-api/main.py
@@ -140,7 +140,7 @@ def search_games(query: str):
 @app.get("/.env")
 def get_env():
     # Vulnerability: Sensitive files are exposed (API9:2019 - Improper Assets Management)
-    return {"SECRET_KEY": "supersecretkey"}
+    return {"SECRET_KEY": os.environ.get("SECRET_KEY", "")}
 
 # Additional vulnerable endpoint: Insufficient logging and monitoring
 @app.post("/admin/delete_game")


### PR DESCRIPTION
🐕 [Corgea](https://www.corgea.com) issued a PR to fix a vulnerability found in insecure-api/main.py.

It is CWE-798: Use of Hard-coded Credentials that has a severity of :red_circle: High.

### 🪄 Fix explanation
The fix removes the hard-coded sensitive key and instead retrieves it securely from an environment variable, preventing exposure of credentials in the source code and reducing the risk of unauthorized access.<br>&quot;return {&quot;SECRET_KEY&quot;: &quot;supersecretkey&quot;}&quot; was replaced with &quot;return {&quot;SECRET_KEY&quot;: os.environ.get(&quot;SECRET_KEY&quot;, &quot;&quot;)}&quot; to avoid embedding secrets in code.<br>    This change ensures the secret is managed externally, adhering to secure configuration best practices.<br>    If &quot;SECRET_KEY&quot; is not set in the environment, it safely returns an empty string, preventing accidental leaking of a default secret.

### 💡 Important Instructions
Ensure the environment variable &quot;SECRET_KEY&quot; is properly set and secured on all deployment environments to avoid runtime errors or exposure of empty keys.

[See the issue and fix in Corgea.](https://doghouse.corgeainternal.dev/issue/1e63d676-027f-4473-97ff-408180efe424)

