### PR TITLE
test: add eval RCE + path traversal to test Corgea blocking rules

### DIFF
--- a/insecure-app/app.py
+++ b/insecure-app/app.py
@@ -179,5 +179,14 @@ def read_file():
         return f.read()
 
 
+# 11 - SSRF via user-controlled URL fetch (CWE-918) — HIGH
+@app.route('/fetch', methods=['GET'])
+def fetch_url():
+    import urllib.request
+    url = request.args.get('url', '')
+    with urllib.request.urlopen(url) as resp:
+        return resp.read()
+
+
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=8080, debug=True)

--- a/insecure-app/app.py
+++ b/insecure-app/app.py
@@ -164,5 +164,20 @@ def index():
         <pre>{{ output|safe }}</pre>
     """, output=output)
 
+# 9 - Remote Code Execution via eval (CWE-94) — CRITICAL
+@app.route('/calc', methods=['GET'])
+def calc():
+    expr = request.args.get('expr', '')
+    return jsonify({'result': eval(expr)})
+
+
+# 10 - Path Traversal via unsanitized file read (CWE-22) — HIGH
+@app.route('/read', methods=['GET'])
+def read_file():
+    name = request.args.get('name', '')
+    with open(os.path.join('/var/data', name)) as f:
+        return f.read()
+
+
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=8080, debug=True)


### PR DESCRIPTION
## Purpose
**Do not merge.** PR exists to verify that Project Tag rules block on Critical and High findings reported by Corgea.

## Changes
Two new Flask endpoints in `insecure-app/app.py`:

| Endpoint | Vulnerability | CWE | Expected severity |
|---|---|---|---|
| `GET /calc?expr=...` | `eval()` on user input | CWE-94 (Code Injection) | Critical |
| `GET /read?name=...` | `open(os.path.join('/var/data', name))` with no sanitization | CWE-22 (Path Traversal) | High |

## Expected behavior
Corgea scan should flag both findings; the configured Project Tag blocking rule should mark this PR as blocked.

## Test plan
- [ ] Corgea scan completes on this PR
- [ ] `/calc` flagged Critical
- [ ] `/read` flagged High
- [ ] PR blocked by Project Tag rule
- [ ] Close PR without merging once verified